### PR TITLE
chore(deps): resolve flake8 bandit conflict

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,7 +1,6 @@
 autopep8==1.6.0
-bandit==1.7.2
 flake8==4.0.1
-flake8-bandit==2.1.2
+flake8-bandit==3.0.0
 flake8-broken-line==0.4.0
 flake8-bugbear==22.3.23
 flake8-cognitive-complexity==0.1.0


### PR DESCRIPTION
Upgrade flake8-bandit to 3.0.0 in order to fix previous conflict with bandit's 1.7.3 release